### PR TITLE
User Operated Internet fund - Request for Guidance

### DIFF
--- a/projects/2021_05_09_user_operated_internet_fund.md
+++ b/projects/2021_05_09_user_operated_internet_fund.md
@@ -1,0 +1,285 @@
+# User Operated Internet Fund
+* Project Name: User Operated Internet Fund
+* Contact Email: cjd@cjdns.fr
+* Project participants:
+  * Caleb James DeLisle
+  * Michiel Leenaars
+  * Bob Goudriaan
+* Projected duration: 8 months + time needed to spend remaining budget
+* Projected effort: Not specified, see accounting section for details
+* Pre-project effort: -
+* Requested PKT contribution: 10mn, 20mn, 30mn, OR 40mn PKT
+  * This project can operate with as little as 10mn PKT, but can effectively deploy as much as 40mn PKT, so we request that the network steward votes this project as though it were 4 separate projects such that other proposals which are deemed better than this project can win and this project will still be able to deploy some resources.
+* PKT address to pay to: pkt1qku865lg0jxkwpl4pvrp8wkzkkjwna4y8ts243v
+
+## Project summary
+
+This project will take PKT into *Stichting Network Steward Trust*, a Netherlands not-for-profit foundation (hereafter called "the Trust") set up especially to manage cryptocurrency assets dedicated to the public benefit. The Trust is open to any donations of cryptocurrencies serving its mission. PKT held in this entity is subgranted to a professional grant fund managed by the [NLnet Foundation](https://nlnet.nl), a recognised and forward-looking philantropic organisation established in 1989 in the Netherlands. The fund provides EUR denominated micro-grants to individuals and teams with projects considered relevant to the PKT ecosystem.
+
+This setup allows to provide and manage much more fine-grained mechanisms that deliver subgrants to the community through e.g. open, competitive calls which are open to individuals and organisations of any type from around the world. A dedicated full-fledged fund with a long term roadmap also allows to arrange for various horizontal support mechanisms to provide quality measures, liaise with the technical and operational internet community, the press as well as create consistency and synergy across a large set of smaller efforts. Being part of a larger whole and receiving tailored support helps boost the maturity of outcomes (through e.g. standardisation in bodies like IETF, IEEE and W3C) as well as improve real-world deployability. Such horizontal support measures includes involving specialised community partners (typically not-for-profits themselves) to provision grant beneficiaries with e.g. security audits, accessibility, packaging, software testing and documentation.
+
+Working through an established philantropical organisation brings along strict regulatory oversight, transparency and professional financial management, and as such delivers strong guarantees regarding avoiding conflict of interest, corruption, and fraud. Dealing with a proper legal entity also provides significantly more legal guarantees to the people involved in projects, given them piece of mind about their efforts.
+
+## Team and Past Work
+
+The following people will comprise the board of stichting Network Steward Trust:
+
+* Caleb James DeLisle - The original author of the PKT software and cjdns, will take a light handed role, he will *not* evaluate projects nor influence the evaluation process, but will be able to veto a project if it is seen as unacceptable use of Network Steward resources.
+
+* [Bob Goudriaan](https://nlnet.nl/people/goudriaan) - General director of NLnet foundation, the philantropic organisation that will perform the grantmaking for the User Operated Internet fund. He is on the advisory board of many different programmes with the Next Generation Internet ecosystem, such as NGI Pointer, NGI DAPSI, NGI LEDGER and TETRA - which jointly manage tens of millions of investment into public benefit R&D. He is a board member of DINL. Since 2014 he has been involved with the ethical security company Radically Open Security, a socially driven enterprise that has meanwhiled donated over half a million euro of its profits to NLnet foundation. Goudriaan studied fiscal law at Leiden University, and afterwards moved back and forth between functions with large organisations like PWC and Deloitte across the globe and entrepreneurial activities. Goudriaan was previously partner and co-founder of the Amsterdam based management consultancy Gendo, specialised in technological innovation. He will be responsible for the financial, regulatory and fiscal management of the User Operatered Internet Fund.
+
+* [Michiel Leenaars](https://nlnet.nl/people/leenaars.html) - Director of Strategy at NLnet Foundation. He is responsible for defining and initating short term and long term policies and managing strategic activities within the NLnet foundation, and acts as its spokesperson to the press and society. He is also a liaison for W3C Benelux, and is on the board/supervisory board of various organisations such as The Commons Conservancy, OpenDoc Society, SIDN Fund and Petities.nl. He was a member of the UNESCO PERSIST Technical Taskforce, and the IPDC/IFAP working group at UNESCO NL. He served on the strategic committee of EUrid, the European domain name registry. He will be responsible for coordinating project evaluations within the User Operated Internet Fund.
+
+The daily work within the project will be done by the professional staff of NLnet Foundation. 
+
+## Project deliverables
+
+The deliverables from the trust will be reports describing the management level view of the User Operated Internet Fund from the perspective of Trust which is managing the crypto assets. The "real" deliverables are created by a large amount of smaller projects running in parallel - each with their own timelines - with very low overhead within the User Operated Internet Fund managed by a professional grant making organisation.
+
+Each project delivers tangible outcomes relevant to the scope of the fund, and is paid incrementally after these results have been verified.
+
+Each deliverable report from the Trust will include:
+
+1. The balance of payments to the User Operated Internet Fund
+2. The amount of money which was converted from PKT during the reported period
+3. For each event of selling PKT by the Trust, the following information:
+  * Date
+  * Amount of PKT
+  * Strike price
+  * Purpose (either for newly signed projects, or administrative costs)
+  * Balance of PKT, EUR, and other assets remaining at that time
+4. An overview of the financial status of the fund, including a breakdown of costs (including administrative costs) and financial interaction with the Trust
+5. The composition of the team responsible for the operation of the fund, brief description of tasks and responsibilities and total hours worked on administrative tasks in the period.
+6. For each active funded project: An executive summary and current status of the project, as well as links to deliverables.
+7. For each active funded project which is classied as a *support activity*: A management overview of the use of resources, remaining budget, and which projects were supported.
+8. Attestation by a legal representative which confirms:
+  * That the above transaction and balance information is truly accurate
+  * That payments to projects have been made after the agreed results have been delivered
+
+**NOTE**: *Stichting NLnet* and *Stichting Network Steward Trust* and will both publish an official audit by a chartered accountant after the end of each book year. This will confirm and formalise any attestations made by their legal representatives.
+
+## Bylaws
+
+In the management of PKT allocated to this project, the Trust commits to the following conditions:
+
+1. The Network Steward will be informed within 24 hours of any sale of the PKT allocated for the User Operated Internet fund, the sale will include the amount and exchange rate.
+2. PKT for funding each consecutive round is converted to EUR when that round has been evaluated.
+3. Administrative costs associated with a project will be established at a fixed rate of 10% of the overall project cost, in accordance with the fixed cost methodology used by EU project funding.
+4. Total administrative costs for project-related and non-project-related administration cannot exceed 15% of the entire expended budget.
+5. Total cost of support projects (e.g. security audits, legal support, etc) shall not exceed 30% of the entire expended budget.
+6. No person or entity shall receive more than 50,000 EUR for a first project, higher denominations will be considered on a case-by-case basis for entities who have already completed one or more project successfully.
+7. Donations are paid after delivery of agreed milestones, priced in EUR. Grantees may request any portion of the donation they are subsequently entitled to - by virtue of having completed the agreed self-assigned tasks - to be made in PKT. The amount of PKT transferred to the recipient will determined by the day price of PKT at the time of the payment. Stichting Network Steward Trust will arrange for the necessary amount of PKT to be made available for this purpose, keeping track of every conversion (as previously stated); the balance will be settled with the next donation from the Trust to the Fund.
+8. Caleb will not have a role in evaluating projects or any influence in order to make a proposal pass, but will have the ability to veto a project proposal which is considered unacceptable use of Network Steward funds.
+
+### Conflict of interest policy
+
+The Trust for now only has one goal, which is to provision funds to the User Operated Internet Fund. The Trust serves as an intermediary treasurer, and operates within a long term relationship with a recognised philantropic organisation. Should the Trust no longer serve its purpose, the Network Steward will no longer allocate new budget. With almost no moving parts and statutory conditions that are locked down, no conflict of interest is foreseen there.
+
+At the level of the User Operated Internet fund, there is a strict hygienic regime. Reviews are done exclusively by full time professional staff of a recognised and professionally audited public benefit organisation with a significant track record (NLnet foundation), hired to perform impartial and objective project reviews without economic interest, political or national affinity. Every project is reviewed by multiple full time staff members. There is a Conflict of Interest policy in place both for *institutional* conflicts of interest, and *personal* conflicts of interest.
+
+#### Institutional conflicts of interest
+
+As the organisation responsible for the day to day management of the User Operated Internet Fund and its review process, NLnet foundation seeks strong guarantees it does not in any way have any financial or other benefit from awarding certain proposals over others. Note that NLnet foundation is entirely independent, and has been so ever since it was founded in 1989. Stichting NLnet currently has no organisational ties with other legal entities – with the noted exception of its wholly owned fiscal fundraising entity Commons Caretakers BV, which for obvious reasons is excluded from requesting any grants from any fund operated by NLnet. As part of managing its own financial endowment, NLnet has some small historical investments in SME companies and small investment funds. Companies financially invested in by NLnet are also explicitly excluded from receiving any grants through UIO.
+
+#### Personal conflicts of interest
+
+Reviews are performed exclusively by full time professional staff, hired to perform impartial and objective project reviews without economic interest, political or national affinity. For obvious reasons, NLnet staff are not allowed to have any financial or other personal benefit from grant proposals they are responsible for reviewing in any way either – other than the longer term public benefit. This allows them to fulfil their tasks in an impartial manner. The same holds for those people with which the reviewers have close family ties (spouse, domestic or non-domestic partner, child, sibling, parent etc.), and for any legal entities in which NLnet (or its staff) may hold stocks, shares or other economic rights. 
+
+### Membership of reviewers in associations, standards bodies and not-for-profits
+
+Note that the above explicitly does allow for past and present non-remunerate involvement of reviewers in *not-for-profit* legal entities serving the public interest, including those that were part of previously funded efforts. This also includes paid and unpaid (board) membership of professional or ideological organisations such as ACM, IEEE, Internet Society, FSF, ICANN, OSI and Unix user groups, legal umbrellas such as The Commons Conservancy as well as standards bodies like OASIS, W3C, ISO and IEC.
+
+Submissions from those organisations (and other people involved with them) are not considered to constitute a conflict of interest. The ‘reviewer paradox’ is similar to the more classical ‘observer paradox’: in order to be able to properly review the relevance of proposed R&D at the cutting edge of technology, reviewers have to have a level of knowledge that only exists within the R&D ecosystem itself. 
+
+We believe it would not be proportional to exclude members of associations and volunteers within not-for-profits to exclude them from receiving support from UOF, and we believe the ample additional quality assurances allow for this sane approach. 
+
+## Selection criteria
+
+The objective of this project is to provide the same service that is provided by the PKT Network Steward, professionally managed and transparently audited, at significant scale and with a fine granularity (to also cater for worthwhile small projects). The goal is to fund the build-out of the ecosystem by allocating funds to important projects which will benefit everyone in the ecosystem and society at large - especially those projects which would probably not be possible otherwise.
+
+Projects will be evaluated based on their *technical merits*, *expected impact/strategic relevance* and overall *value for money* during a two stage process by expert reviewers on the same criteria on a 7 point Likert-type scale:
+
+- Technical excellence/feasibility (30%)
+- Cost effectiveness/Value for money (30%)
+- UOI Relevance/Impact/Strategic potential (40%)
+
+The overall weighted score determines whether a project is selected or not, with a weighted score of 5.0 out of 7 being the threshold.
+
+### Technical excellence/feasibility
+
+This captures the expert assessment with regards to the technical excellence and feasiblity of the proposed project. Does the proposed project address a real issue worth solving in a realistic and responsible way? Is the approach consistent and informed? Is the applicant qualified and intrinsically motivated to take on the project? A rating of 1 indicates "Strong negative sentiment" and 7 is "Strong positive sentiment". 
+
+In other words: a rating of 1 means the project scores miserably (compared to similar efforts and/or the state of the art), and a rating of 7 means that a project is technically excellent and satisfies this criterion really well.
+
+(This metric is common to project evaluation for all NLnet funding calls)
+
+### Cost effectiveness/Value for money
+
+This establishes whether a proposed project is efficient and frugal, and represents good value for money. This goes beyond just applying a reasonable hourly rate, and basically also determines whether the overall budget requested is effective and 'worth it'. 
+
+A rating of 1 indicates that the evaluators feel the project is beyond just wasting money, and that it would be undesirable or even obscene to fund. A score of 7 ("Extremely good value for money") means that the review considers the requested budget of the project to represent great value for money, and that the overall cost is very low given the effort involved in terms of quality and quantity.
+
+(This metric is common to project evaluation for all NLnet funding calls)
+
+### UOI Relevance/Impact/Strategic potential
+
+Projects are rated given their potential for significant impact or societal return, or by virtue of having a strategic dimension to the goals of the User Operated Internet Fund.
+
+This metric is structured so as to focus on topics with the greatest relevance to the long term vision of the fund - yet not to create a "cliff" where an otherwise very high value project would be excluded for falling just slightly outside of the defined scope.
+
+A score of 7 ("Extremely relevant") means that the project is not only very pertinent to the call but also significant qualitative or quantitative output is expected. A rating of 1 would indicate that the project is seen as potentially counterproductive, and funding the project might actually risk having a net negative impact or endangering the goals of the UOI fund.
+
+(This metric is specific to the *User Operated Internet Fund*)
+
+#### PKT Vision
+
+Though the PKT vision is documented in plenty of other places, we wanted to synthesize it in a few paragraphs here for the purpose of the review process by the Network Steward.
+
+The PKT vision is to get the next billion people online by decoupling infrastructure operation from internet service provision in order to lower the barrier of entry for people to own and operate their own parts of the internet. The PKT blockchain provides a digital currency to facilitate micro-payments to the infrastructure operators who may in many cases be individuals or small community groups for whom the friction of transacting through national banking systems is too high.
+
+PKT is by no means the first project to combine digital micropayments with networking, but there are two aspects which make the PKT vision unique.
+
+1. Rather than attempting to price bandwidth algorithmically, PKT aims to facilitate a decentralized bandwidth marketplace where bandwidth price can be established in the same way that commodity prices have been established for centuries.
+2. Rather than attempting to design a network with no administrator, PKT aims to preserve the network administrator role but to disconnect it from the operation of infrastructure.
+
+The larger societal context is of course that what is good for the resilience, trustworthiness and openness of the internet, is good for the PKT community.
+
+We note the strong overlap with the [vision of the Next Generation Internet](https://nlnet.nl/NGI/vision) initiative, and will seek to bridge these efforts.
+
+#### Evaluation scope
+
+With this vision in mind, the topics to be funded through this project fall in four categories:
+
+1. Projects which directly contribute to furthering the PKT Vision, such as building software which will be used by Cloud ISPs and infrastructure operators.
+2. Building and maintaining the common tools and infrastructure which are used by the community to further the vision.
+  * Examples of projects on this topic might include improvements to online chat tools, documentation tooling, or project management platform.
+3. The technological infrastructure upon which the internet and PKT rely, or may rely in the future.
+  * Projects in this category might include open hardware for free space optics or wireless chips.
+4. Particularly high value projects which contribute to the internet being a positive force for society.
+
+By design and by choice all project results need to be available under a recognised free and open source license. As per the requirement of the PKT Network Steward, projects should not be unfairly beneficial to any one person or entity over any other. As an example, a project which appears as though it would create significant margin for the applicant should be disqualified.
+
+#### Who can apply?
+
+Anyone that can bring a relevant contribution to the goals of the fund can apply - whether they are a natural person or an organisation of any type that wants to improve and further develop relevant technologies and related enabling efforts. Applicants can be based anywhere (no geo-restrictions), and can remain anonymous during submission and evaluation, if they so desire. The only thing that counts is a good idea coupled with the ability to properly execute it.
+
+Minors that have not yet reached the age of legal consent in their country of origin on the date of the deadline may also apply; consent from a legal representative such as a parent does not have to be provided prior to initial submission. Such consent will be necessary should the project proposal be granted.
+
+## Milestones
+
+The milestones in this project will follow the NLnet funding cadence of:
+
+* An open call beginning every 2 months
+* Each call having 2 month long submission window
+* And final notice of acceptance 6 to 8 weeks after call deadline
+
+Milestone 1 will be a setup milestone with minimal expenditure and no additional funds requested.
+
+After Milestone 4, there will be subsequent milestones until all funds have been allocated.
+
+### Milestone 0 (Kickoff)
+
+After the project is accepted, the Network Steward will pay 1/4 of the overall budget (henceforth: Buffer Amount) in PKT to the Trust.
+
+If approved by the Network Steward, the fund will be established immediately and the first open call (2021-08U) will open up June 1st 2021, with a deadline of August 1st 2021 12:00 CEST.
+
+### Milestone 1
+
+The User Operated Internet Fund at NLnet Foundation will set up the infrastructure, create a skeleton budget for the first project round of the competitive open call, hire necessary additional staff and incrementally report the costs incurred to the Trust which will convert PKT to EUR in order to pay these costs. At this point the only costs incurred will be administrative.
+
+The second call (2021-10U) opens on August 1st 2021, with deadline October 1st.
+
+On August 5th 2021, a deliverable report will be produced by no additional funding will be requested. This includes metrics of applicants to the first round.
+
+### Milestone 2
+
+This milestone will include the selected grantees from the first open call (2021-08U). Just prior to the submission, the PKT necessary to fund the projects will be converted by the Trust. We will also include metrics of applicants to the second round (2021-10U).
+
+This milestone will be submitted no later than October 5th 2021.
+
+After a report is delivered on this milestone and if it is approved by the NS, the NS will send the amount of PKT needed to raise the balance of the Trust's treasury to the Buffer Amount.
+
+### Milestone 3
+
+This milestone will include the selected grantees from the second open call (2021-10U). Again, prior to the submission, the PKT necessary to fund the projects will be converted by the Trust. We will once more include metrics of applicants, this time to the third round (2021-12U). In this report we will also provide information about the ongoing projects.
+
+This milestone will be submitted no later than December 5th 2021.
+
+After a report is delivered on this milestone and if it is approved by the NS, the NS will send the amount of PKT needed to raise the balance of the Trust's treasury to the Buffer Amount.
+
+### Milestone 4
+
+This milestone will include the selected grantees from the third open call (2021-12U). Once more, prior to the submission, the PKT necessary to fund the projects will be converted by the Trust. We will again include metrics of applicants, this time to the third round. In this report we will also provide information about the ongoing projects.
+
+This milestone will be submitted no later than February 5th 2022.
+
+After a report is delivered on this milestone and if it is approved by the NS, the NS will send the amount of PKT needed to raise the balance of the Trust's treasury to the Buffer Amount.
+
+### Subsequent milestones
+
+If necessary, additional milestones are added until the available budget in PKT is allocated to projects. Subsequent milestones (those beyond milestone 4) will continue to happen along the same formula as described above. New calls will continue to be opened until the entire budget has been allocated and regular reports on projects will continue to be made until the funds have been dispursed.
+
+### Success criteria
+
+Deliverable reports will include all information specified in the above section *Deliverable report* and concrete success criteria in the section "Milestones".
+
+We consider the project to be a success:
+
+- competitive open calls take place every two months
+- proposal evaluations are delivered before the next call closes, to allow for quick iterations
+- the projects selected are of high technical quality and deliver concrete and meaningful results pertinent to the fund
+- all projects outcomes are made available to the whole community under an open license prior to payment
+- all delivered results are evaluated and match the agreed tasks and milestones
+- payment takes place within four weeks after results are delivered
+
+## Disclosure
+
+I hereby submit this application in good faith and I attest that I have made no effort, nor do I intend to make effort, influence the Network Steward to accept this or any other project I have submitted.
+
+*Please check one or more:*
+
+1. Conflicts
+  1. [x] An organization is receiving the funds
+    1. [x] Organization has financial relationships with one or more reviewers: Caleb James DeLisle
+    2. [ ] Organization has no financial relationships with any reviewers
+  2. [ ] An individual is receiving the funds
+    1. [ ] Individual works for same organization as one or more reviewers: *specify whom*
+    2. [ ] Individual has other financial relationships with one or more reviewers: *specify whom*
+    3. [ ] Individual does not work for the same organization as any reviewer
+2. No Pumping
+  1. [ ] Project results will present information which might lead to PKT price speculation
+    * If selected, please attach a paragraph detailing the information which will be presented and any steps which will be taken to prevent this from potentially misleading the public.
+  2. [x] Project results will not present information which might lead to PKT price speculation
+
+## Use of Resources
+Each milestone report will be accompanied by:
+
+* [x] Itemization of project expenditures, including description, date and price (in national currency)
+  * [x] Justification of this itemization in an audit certificate
+* [x] Dates when PKT was converted to national currency
+  * [x] Justification of this conversion in an audit certificate
+* [x] An audit certificate from a qualified financial auditor
+  * NLnet foundation is audited by Koningsbos Accountants
+    Science Park 400
+    1098 XH Amsterdam
+    The Netherlands
+    https://www.koningsbos-acc.nl
+    Koningsbos Accountants BV is a member of NBA (The Royal Netherlands Institute of Chartered Accountants), SRA (Cooperation of register accountants and administrative consultants) and has a license from the AFM (Netherlands Authority Financial Markets).
+
+**NOTE**: The audit will be published in May of the following year. Also see additional documentation in section *Deliverable reports*
+
+### Partial milestones
+If it happens that we have satisfied all of the criteria for a milestone but have not provided
+justification of all resources allocated *(choose one)*:
+
+* [x] We will deduct the un-justified amount from the amount requested for the milestone
+* [ ] We will request the milestone be paid in full anyway
+
+## Legal
+
+The applicant understands that the network steward is not a legal entity and no part of this project constitutes any form of legal agreement. The applicant accepts that the network steward exists thanks to the effort of volunteers and the applicant has no reasonable expectation of any action, payment or communication from the network steward at any time. For their part, the applicant has no binding commitment or obligation at any time as a result of their participation
+in this project.
+
+## Project Status
+
+* Seeking guidance

--- a/projects/2021_05_09_user_operated_internet_fund.md
+++ b/projects/2021_05_09_user_operated_internet_fund.md
@@ -9,22 +9,36 @@
 * Projected effort: Not specified, see accounting section for details
 * Pre-project effort: -
 * Requested PKT contribution: 10mn, 20mn, 30mn, OR 40mn PKT
-  * This project can operate with as little as 10mn PKT, but can effectively deploy as much as 40mn PKT, so we request that the network steward votes this project as though it were 4 separate projects such that other proposals which are deemed better than this project can win and this project will still be able to deploy some resources.
+  * This project can operate with as little as 10mn PKT, but can effectively deploy as much as 40mn PKT
+  * In order to achieve flexible budget within the rules of the network steward, we propose this as 4 separate projects: UOI_1, UOI_2, UOI_3 and UOI_4, which are each identical 10mn PKT proposals.
+  * We suggest that if the network steward chooses to score these 4 projects differently, that it places the higher scores on the lower number project numbers such that UOI_1 has the highers chance of winning, but this is only a suggestion.
 * PKT address to pay to: pkt1qku865lg0jxkwpl4pvrp8wkzkkjwna4y8ts243v
 
 ## Project summary
 
-This project will take PKT into *Stichting Network Steward Trust*, a Netherlands not-for-profit foundation (hereafter called "the Trust") set up especially to manage cryptocurrency assets dedicated to the public benefit. The Trust is open to any donations of cryptocurrencies serving its mission. PKT held in this entity is subgranted to a professional grant fund managed by the [NLnet Foundation](https://nlnet.nl), a recognised and forward-looking philantropic organisation established in 1989 in the Netherlands. The fund provides EUR denominated micro-grants to individuals and teams with projects considered relevant to the PKT ecosystem.
+This project will take PKT into *Stichting Technology Commons Trust*, a Netherlands not-for-profit foundation (hereafter called "the Trust") set up especially to manage cryptocurrency assets dedicated to the public benefit. The Trust is open to any donations of cryptocurrencies serving its mission. PKT held in this entity is subgranted to a professional grant fund managed by the [NLnet Foundation](https://nlnet.nl), a recognised and forward-looking philantropic organisation established in 1989 in the Netherlands. The fund provides EUR denominated micro-grants to individuals and teams with projects considered relevant to the PKT ecosystem.
 
-This setup allows to provide and manage much more fine-grained mechanisms that deliver subgrants to the community through e.g. open, competitive calls which are open to individuals and organisations of any type from around the world. A dedicated full-fledged fund with a long term roadmap also allows to arrange for various horizontal support mechanisms to provide quality measures, liaise with the technical and operational internet community, the press as well as create consistency and synergy across a large set of smaller efforts. Being part of a larger whole and receiving tailored support helps boost the maturity of outcomes (through e.g. standardisation in bodies like IETF, IEEE and W3C) as well as improve real-world deployability. Such horizontal support measures includes involving specialised community partners (typically not-for-profits themselves) to provision grant beneficiaries with e.g. security audits, accessibility, packaging, software testing and documentation.
+This setup allows us to provide and manage much more fine-grained mechanisms that deliver subgrants to the community through e.g. open, competitive calls which are open to individuals and organisations of any type from around the world. A dedicated full-fledged fund with a long term roadmap also allows to arrange for various horizontal support mechanisms to provide quality measures, liaise with the technical and operational internet community, the press as well as create consistency and synergy across a large set of smaller efforts. 
+
+Being part of a larger whole and receiving tailored support helps boost the maturity of outcomes (through e.g. standardisation in bodies like IETF, IEEE and W3C) as well as improve real-world deployability. Such horizontal support projects includes involving specialised community partners (typically not-for-profits themselves) to provision grant beneficiaries with e.g. security audits, accessibility, packaging, software testing and documentation.
 
 Working through an established philantropical organisation brings along strict regulatory oversight, transparency and professional financial management, and as such delivers strong guarantees regarding avoiding conflict of interest, corruption, and fraud. Dealing with a proper legal entity also provides significantly more legal guarantees to the people involved in projects, given them piece of mind about their efforts.
 
+### Project Types
+
+There are two types of projects, *regular projects* and *support projects*. Regular projects are proposed by individuals and organisations of any type from around the world and are evaluated by professional evaluators.
+
+Support projects provide auxiliary supporting activities to the regular projects in order to help them reach maturity. Our experience is that deeply technical projects run by individuals or small teams have limited resources to deal with a large amount of responsibility, while at the same time already having committed to very challenging and complex tasks. One cannot expect mere mortals to not only be top researchers and developers and at the same time to be experts in security, the global landscape of IP and copyright law or have a turn-key network in standards-setting organisations - and yet successful projects will need to face the hostile environment of the modern internet, deal with copyright trolls or complex licensing issues or other challenges.
+
+A non-exhaustive list of examples of such supporting activities from the current portfolio of NLnet are security audits, copyright compliance checks, software testing, support for internationalisation/localisation, accessibility certification, formal verification of protocols, fuzzing, usability testing, support with standardisation etcetera. Such a support pipeline of specialised services provided by domain experts is a cost-effective way to accelerate the development and quality of projects. The services complement the skills present within the project teams, and the addition of domain knowledge helps to avoid beginner mistakes and speeds up building capacity within the teams themselves. 
+
+One important thing to note is that all parties (both regular projects and support projects) *choose* to collaborate with each other. This voluntarily aspect is essential for meaningful results. A project does not have to accept any help from a support service, let alone does it have to subject itself to services it deems unnecessary, distracting or somehow not suitable - but support services also get to choose which projects they help out as well. There is no hierarchy between these two: the people within support projects may have generously opted to primarily serve the ideas of others with their skills and time, but they do not get compensated for their help at market prices and cannot be forced to do anything they are not fully aligned with or feel they can add enough value to (nor would that be desirable). There are no contracts in place, and thus each party must assess whether there is a fertile match for collaboration. Only if both parties see the value of working together, will any effort take place. Of course, no payments are made to service projects if no service is delivered.
+
 ## Team and Past Work
 
-The following people will comprise the board of stichting Network Steward Trust:
+The following people will comprise the board of stichting Technology Commons Trust:
 
-* Caleb James DeLisle - The original author of the PKT software and cjdns, will take a light handed role, he will *not* evaluate projects nor influence the evaluation process, but will be able to veto a project if it is seen as unacceptable use of Network Steward resources.
+* Caleb James DeLisle - The original author of the PKT software and cjdns, will take a light handed role, he will *not* evaluate projects nor influence the evaluation process.
 
 * [Bob Goudriaan](https://nlnet.nl/people/goudriaan) - General director of NLnet foundation, the philantropic organisation that will perform the grantmaking for the User Operated Internet fund. He is on the advisory board of many different programmes with the Next Generation Internet ecosystem, such as NGI Pointer, NGI DAPSI, NGI LEDGER and TETRA - which jointly manage tens of millions of investment into public benefit R&D. He is a board member of DINL. Since 2014 he has been involved with the ethical security company Radically Open Security, a socially driven enterprise that has meanwhiled donated over half a million euro of its profits to NLnet foundation. Goudriaan studied fiscal law at Leiden University, and afterwards moved back and forth between functions with large organisations like PWC and Deloitte across the globe and entrepreneurial activities. Goudriaan was previously partner and co-founder of the Amsterdam based management consultancy Gendo, specialised in technological innovation. He will be responsible for the financial, regulatory and fiscal management of the User Operatered Internet Fund.
 
@@ -34,7 +48,7 @@ The daily work within the project will be done by the professional staff of NLne
 
 ## Project deliverables
 
-The deliverables from the trust will be reports describing the management level view of the User Operated Internet Fund from the perspective of Trust which is managing the crypto assets. The "real" deliverables are created by a large amount of smaller projects running in parallel - each with their own timelines - with very low overhead within the User Operated Internet Fund managed by a professional grant making organisation.
+The deliverables from the trust to the Network Steward will be reports describing the management level view of the User Operated Internet Fund from the perspective of Trust which is managing the crypto assets. The "real" deliverables are created by a large amount of smaller projects running in parallel - each with their own timelines - with as low overhead as possible, courtesy of the User Operated Internet Fund being managed by a professional grant making organisation through an established process.
 
 Each project delivers tangible outcomes relevant to the scope of the fund, and is paid incrementally after these results have been verified.
 
@@ -51,12 +65,12 @@ Each deliverable report from the Trust will include:
 4. An overview of the financial status of the fund, including a breakdown of costs (including administrative costs) and financial interaction with the Trust
 5. The composition of the team responsible for the operation of the fund, brief description of tasks and responsibilities and total hours worked on administrative tasks in the period.
 6. For each active funded project: An executive summary and current status of the project, as well as links to deliverables.
-7. For each active funded project which is classied as a *support activity*: A management overview of the use of resources, remaining budget, and which projects were supported.
+7. For each active funded project which is classied as a *support project*: A management overview of the use of resources, remaining budget, and which projects were supported.
 8. Attestation by a legal representative which confirms:
   * That the above transaction and balance information is truly accurate
   * That payments to projects have been made after the agreed results have been delivered
 
-**NOTE**: *Stichting NLnet* and *Stichting Network Steward Trust* and will both publish an official audit by a chartered accountant after the end of each book year. This will confirm and formalise any attestations made by their legal representatives.
+**NOTE**: *Stichting NLnet* and *Stichting Technology Commons Trust* will both publish an official audit by a chartered accountant after the end of each book year. This will confirm and formalise any attestations made by their legal representatives.
 
 ## Bylaws
 
@@ -66,10 +80,11 @@ In the management of PKT allocated to this project, the Trust commits to the fol
 2. PKT for funding each consecutive round is converted to EUR when that round has been evaluated.
 3. Administrative costs associated with a project will be established at a fixed rate of 10% of the overall project cost, in accordance with the fixed cost methodology used by EU project funding.
 4. Total administrative costs for project-related and non-project-related administration cannot exceed 15% of the entire expended budget.
-5. Total cost of support projects (e.g. security audits, legal support, etc) shall not exceed 30% of the entire expended budget.
-6. No person or entity shall receive more than 50,000 EUR for a first project, higher denominations will be considered on a case-by-case basis for entities who have already completed one or more project successfully.
-7. Donations are paid after delivery of agreed milestones, priced in EUR. Grantees may request any portion of the donation they are subsequently entitled to - by virtue of having completed the agreed self-assigned tasks - to be made in PKT. The amount of PKT transferred to the recipient will determined by the day price of PKT at the time of the payment. Stichting Network Steward Trust will arrange for the necessary amount of PKT to be made available for this purpose, keeping track of every conversion (as previously stated); the balance will be settled with the next donation from the Trust to the Fund.
-8. Caleb will not have a role in evaluating projects or any influence in order to make a proposal pass, but will have the ability to veto a project proposal which is considered unacceptable use of Network Steward funds.
+5. Support projects (e.g. security audits, legal support, etc) shall not make any spending at all, except at the direction of grantees of regular projects and shall not exceed 30% of the entire expended budget in any case.
+6. In addition to points 4 and 5, at least twothirds (66.6%) of the total fund budget shall be paid out to grantees of regular projects.
+7. No person or entity shall receive more than 50,000 EUR for a first project, higher denominations will be considered on a case-by-case basis for entities who have already completed one or more project successfully.
+8. Donations are paid after delivery of agreed milestones, priced in EUR. Grantees may request any portion of the donation they are subsequently entitled to - by virtue of having completed the agreed self-assigned tasks - to be made in PKT. The amount of PKT transferred to the recipient will determined by the day price of PKT at the time of the payment. Stichting Technology Commons Trust will arrange for the necessary amount of PKT to be made available for this purpose, keeping track of every conversion (as previously stated); the balance will be settled with the next donation from the Trust to the Fund.
+9. Caleb will not have a role in evaluating projects or any influence in order to make a proposal pass.
 
 ### Conflict of interest policy
 
@@ -115,7 +130,7 @@ In other words: a rating of 1 means the project scores miserably (compared to si
 
 ### Cost effectiveness/Value for money
 
-This establishes whether a proposed project is efficient and frugal, and represents good value for money. This goes beyond just applying a reasonable hourly rate, and basically also determines whether the overall budget requested is effective and 'worth it'. 
+This establishes whether a proposed project is efficient and frugal, and represents good value for money. This goes beyond just applying a reasonable hourly or monthly rate, and basically also determines whether the overall budget requested is effective and 'worth it'. 
 
 A rating of 1 indicates that the evaluators feel the project is beyond just wasting money, and that it would be undesirable or even obscene to fund. A score of 7 ("Extremely good value for money") means that the review considers the requested budget of the project to represent great value for money, and that the overall cost is very low given the effort involved in terms of quality and quantity.
 
@@ -164,6 +179,8 @@ By design and by choice all project results need to be available under a recogni
 Anyone that can bring a relevant contribution to the goals of the fund can apply - whether they are a natural person or an organisation of any type that wants to improve and further develop relevant technologies and related enabling efforts. Applicants can be based anywhere (no geo-restrictions), and can remain anonymous during submission and evaluation, if they so desire. The only thing that counts is a good idea coupled with the ability to properly execute it.
 
 Minors that have not yet reached the age of legal consent in their country of origin on the date of the deadline may also apply; consent from a legal representative such as a parent does not have to be provided prior to initial submission. Such consent will be necessary should the project proposal be granted.
+
+These criteria are standard to NLnet project application process.
 
 ## Milestones
 
@@ -232,6 +249,8 @@ We consider the project to be a success:
 - all delivered results are evaluated and match the agreed tasks and milestones
 - payment takes place within four weeks after results are delivered
 
+If at any milestone in the project, the network steward deems funds to have been misappropriated, or used to the detrement of the PKT community or to overall society, the network steward may reject the milestone and suspend funding of the project until all concerns have been addressed to the satisfaction of the network steward.
+
 ## Disclosure
 
 I hereby submit this application in good faith and I attest that I have made no effort, nor do I intend to make effort, influence the Network Steward to accept this or any other project I have submitted.
@@ -239,15 +258,15 @@ I hereby submit this application in good faith and I attest that I have made no 
 *Please check one or more:*
 
 1. Conflicts
-  1. [x] An organization is receiving the funds
-    1. [x] Organization has financial relationships with one or more reviewers: Caleb James DeLisle
-    2. [ ] Organization has no financial relationships with any reviewers
-  2. [ ] An individual is receiving the funds
-    1. [ ] Individual works for same organization as one or more reviewers: *specify whom*
-    2. [ ] Individual has other financial relationships with one or more reviewers: *specify whom*
-    3. [ ] Individual does not work for the same organization as any reviewer
+  * [x] An organization is receiving the funds
+    * [x] Organization has financial relationships with one or more reviewers: Caleb James DeLisle
+    * [ ] Organization has no financial relationships with any reviewers
+  * [ ] An individual is receiving the funds
+    * [ ] Individual works for same organization as one or more reviewers: *specify whom*
+    * [ ] Individual has other financial relationships with one or more reviewers: *specify whom*
+    * [ ] Individual does not work for the same organization as any reviewer
 2. No Pumping
-  1. [ ] Project results will present information which might lead to PKT price speculation
+  * [ ] Project results will present information which might lead to PKT price speculation
     * If selected, please attach a paragraph detailing the information which will be presented and any steps which will be taken to prevent this from potentially misleading the public.
   2. [x] Project results will not present information which might lead to PKT price speculation
 

--- a/projects/2021_05_09_user_operated_internet_fund.md
+++ b/projects/2021_05_09_user_operated_internet_fund.md
@@ -190,7 +190,7 @@ The milestones in this project will follow the NLnet funding cadence of:
 * Each call having 2 month long submission window
 * And final notice of acceptance 6 to 8 weeks after call deadline
 
-Milestone 1 will be a setup milestone with minimal expenditure and no additional funds requested.
+Milestone 1 will be a setup milestone with minimal expenditure. We seek to bootstrap a small call round for the fund with a deadline of June 1st 2021 (which would give candicate projects a week to submit). Given the expected limited number of projects submitting at such short notice, no additional funds should be required.
 
 After Milestone 4, there will be subsequent milestones until all funds have been allocated.
 
@@ -198,43 +198,45 @@ After Milestone 4, there will be subsequent milestones until all funds have been
 
 After the project is accepted, the Network Steward will pay 1/4 of the overall budget (henceforth: Buffer Amount) in PKT to the Trust.
 
-If approved by the Network Steward, the fund will be established immediately and the first open call (2021-08U) will open up June 1st 2021, with a deadline of August 1st 2021 12:00 CEST.
+The User Operated Internet Fund at NLnet Foundation will set up the infrastructure, create a skeleton budget for the first project rounds of the competitive open call, hire necessary additional staff and incrementally report the costs incurred to the Trust which will convert PKT to EUR in order to pay these costs.
+
+A first open call will be announced with a deadline of June 1st ("the June call"). Due to the short time available for submission of proposals, we expect a limited set of applications - which will allow us to test the procedures and prepare for the larger subsequent rounds.
+
+The second open call ("The August call") will open up June 1st 2021, with a deadline of August 1st 2021 12:00 CEST.
 
 ### Milestone 1
 
-The User Operated Internet Fund at NLnet Foundation will set up the infrastructure, create a skeleton budget for the first project round of the competitive open call, hire necessary additional staff and incrementally report the costs incurred to the Trust which will convert PKT to EUR in order to pay these costs. At this point the only costs incurred will be administrative.
+This milestone will be delivered no later than August 5th 2021 and will include the selected grantees from the June call and metrics regarding the applications to the August call. If there are projects from the June call which have already started, information about these will be provided as well. Necessary PKT to fund the new projects will be converted to EUR as the projects are approved.
 
-The second call (2021-10U) opens on August 1st 2021, with deadline October 1st.
+Another call ("The October call") will open on August 1st with deadline October 1st.
 
-On August 5th 2021, a deliverable report will be produced by no additional funding will be requested. This includes metrics of applicants to the first round.
+*No additional funding will be requested at this time*
 
 ### Milestone 2
 
-This milestone will include the selected grantees from the first open call (2021-08U). Just prior to the submission, the PKT necessary to fund the projects will be converted by the Trust. We will also include metrics of applicants to the second round (2021-10U).
+This milestone will be delivered no later than October 5th 2021 and will include the selected grantees from the August projects. The necessary PKT to fund the new projects will be converted to EUR as the projects are approved.
 
-This milestone will be submitted no later than October 5th 2021.
+Another call ("The December call") will open on October 1st with deadline December 1st.
 
 After a report is delivered on this milestone and if it is approved by the NS, the NS will send the amount of PKT needed to raise the balance of the Trust's treasury to the Buffer Amount.
 
 ### Milestone 3
 
-This milestone will include the selected grantees from the second open call (2021-10U). Again, prior to the submission, the PKT necessary to fund the projects will be converted by the Trust. We will once more include metrics of applicants, this time to the third round (2021-12U). In this report we will also provide information about the ongoing projects.
+This milestone will be delivered no later than December 6th 2021 and will include the selected grantees from the October call as well as metrics regarding applications to the December call and information about ongoing projects, the necessary PKT to fund the new projects will be converted to EUR as the projects are accepted.
 
-This milestone will be submitted no later than December 5th 2021.
+Another call ("The February call") will open on December 1st with deadline February 1st.
 
 After a report is delivered on this milestone and if it is approved by the NS, the NS will send the amount of PKT needed to raise the balance of the Trust's treasury to the Buffer Amount.
 
 ### Milestone 4
 
-This milestone will include the selected grantees from the third open call (2021-12U). Once more, prior to the submission, the PKT necessary to fund the projects will be converted by the Trust. We will again include metrics of applicants, this time to the third round. In this report we will also provide information about the ongoing projects.
-
-This milestone will be submitted no later than February 5th 2022.
+This milestone will be delivered no later than February 5th 2021 and will include the selected grantees from the December call, the metrics from the February call. The necessary PKT to fund the new projects will be converted to EUR as the projects are accepted.
 
 After a report is delivered on this milestone and if it is approved by the NS, the NS will send the amount of PKT needed to raise the balance of the Trust's treasury to the Buffer Amount.
 
 ### Subsequent milestones
 
-If necessary, additional milestones are added until the available budget in PKT is allocated to projects. Subsequent milestones (those beyond milestone 4) will continue to happen along the same formula as described above. New calls will continue to be opened until the entire budget has been allocated and regular reports on projects will continue to be made until the funds have been dispursed.
+As necessary, additional milestones are added until the available budget in PKT is allocated to projects. Subsequent milestones (those beyond milestone 4) will continue to happen along the same formula as described above. New calls will continue to be opened until the entire budget has been allocated and regular reports on projects will continue to be made until the funds have been dispursed.
 
 ### Success criteria
 


### PR DESCRIPTION
Hello folks,
I wanted to propose this project as a way to lift the load off of the Network Steward shoulders. I know we all have felt the pressure of the future looking back on us as we try to do our best to allocate resources for the benefit of the ecosystem, and I really appreciate the seriousness which everyone has put on this role. I have put this project together to move the heavy-lifting operations of the Network Steward to a public benefit charity with a legal infrastructure and professional full-time reviewers, so that the heavy lifting can be done by professionals while the oversight remains with the NS team.

I am putting in this project as a Request for Guidance, which means I want your advice:

1. Is this project structurally sound? It has a flexible budget size, is that OK? Is it something that can compete in your mind?
2. We considered using the name "Network Steward Trust" for the Netherlands not-for-profit foundation, is this a fine name or would you prefer we used something different?
3. I put myself as *not* having the ability to influence a project to make it win, yet retain the power of veto in case there is a project which I consider unacceptable / dangerous to be funded from Network Steward resources. Is this a good idea in your mind?
4. This project is meant to serve the NS, is there anything else which you think could make it better?

Thanks,
Caleb